### PR TITLE
Move tag pages under /blog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,6 +18,9 @@ export default defineConfig({
   redirects: {
     // slug lowercased for consistency with the other component docs
     "/components/ReadProgressBar": "/components/readprogressbar",
+    // tags pages moved under /blog so the Blog nav item highlights on them
+    "/tags": "/blog/tags",
+    "/tags/[tag]": "/blog/tags/[tag]",
   },
   integrations: [
     preact(),

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -27,7 +27,7 @@ const {
   imageSrc,
   imageAlt = '',
   tags = [],
-  tagsUrl = '/tags',
+  tagsUrl = '/blog/tags',
   author,
   avatarSrc,
   date,

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -25,7 +25,7 @@ import { VERSION } from '../scripts/globals';
       <ul>
         <li><a href="https://github.com/minimaldesign/mCSS/tree/main/src/styles">Code base</a></li>
         <li><a href="https://github.com/minimaldesign/mCSS/issues">Issue tracker</a></li>
-        <li><a href="/tags/learn">Tutorials, tips & tricks</a></li>
+        <li><a href="/blog/tags/learn">Tutorials, tips & tricks</a></li>
         <li><a href="https://www.youtube.com/">YouTube</a></li>
       </ul>
     </li>

--- a/src/components/Tags.astro
+++ b/src/components/Tags.astro
@@ -15,7 +15,7 @@ interface Props extends HTMLAttributes<'ul'> {
 const {
   tagList = [],
   variant = 'inline',
-  url = "/tags",
+  url = "/blog/tags",
   sort = false,
   class: className,
   'data-testid': testId = 'tags',

--- a/src/content/components/articlecard.mdx
+++ b/src/content/components/articlecard.mdx
@@ -48,7 +48,7 @@ The `.articleCard` component is the blog-index pattern: image, tags, title, desc
 
 <section class="prose">
 
-ArticleCard extends the [card](/components/card) (same border, radius, tokens) and composes [Tags](/components/tags) and [Avatar](/components/avatar); PostList is a `ul` over the [grid system](/docs/global#grid). The card carries **one** link — the title, stretched over the whole card with a `::after` — so screen readers hear one link named by the title, and the tags stay independently clickable above it.
+ArticleCard extends the [card](/components/card) (same border, radius, tokens) and composes [Tags](/components/blog/tags) and [Avatar](/components/avatar); PostList is a `ul` over the [grid system](/docs/global#grid). The card carries **one** link — the title, stretched over the whole card with a `::after` — so screen readers hear one link named by the title, and the tags stay independently clickable above it.
 
 ```html
 <ul class="postList grid" col="1" col-md="2" col-lg="2">
@@ -58,7 +58,7 @@ ArticleCard extends the [card](/components/card) (same border, radius, tokens) a
         <img class="articleCard_image" src="cover.jpg" alt="" loading="lazy" />
       </figure>
       <nav aria-label="Tags"><ul class="tags tags-inline articleCard_tags">
-        <li><a href="/tags/css">css</a></li>
+        <li><a href="/blog/tags/css">css</a></li>
       </ul></nav>
       <h3 class="articleCard_title"><a href="/blog/my-post">Designing with cascade layers</a></h3>
       <div class="articleCard_description"><p>Why layer order beats specificity wars.</p></div>
@@ -103,7 +103,7 @@ Everything else (borders, radius, colors, spacing) comes from the [card tokens](
 | `imageSrc`  | `ImageMetadata \| string` | `undefined` | Cover image (imported asset or URL/path).          |
 | `imageAlt`  | `string`                  | `""`        | Cover image alt text.                              |
 | `tags`      | `string[]`                | `[]`        | Tag names, rendered with the Tags component.       |
-| `tagsUrl`   | `string`                  | `"/tags"`   | Base URL for tag links.                            |
+| `tagsUrl`   | `string`                  | `"/blog/tags"`   | Base URL for tag links.                            |
 | `author`    | `string`                  | `undefined` | Byline name (also feeds the Avatar initials).      |
 | `avatarSrc` | `ImageMetadata \| string` | `undefined` | Byline avatar image.                               |
 | `date`      | `Date`                    | `undefined` | Publication date, rendered as a `<time>`.          |

--- a/src/content/components/tags.mdx
+++ b/src/content/components/tags.mdx
@@ -66,7 +66,7 @@ The following custom properties are available in the [default theme](/docs/theme
 | ------------- | ---------- | ----------- | ----------------------------------------------------------- |
 | `tagList`     | `string[]` | `[]`        | Array of tag strings to display.                            |
 | `variant`     | `string`   | `inline`    | Inline or list layout.                                      |
-| `url`         | `string`   | `/tags`     | Base URL to prepend to each tag.                            |
+| `url`         | `string`   | `/blog/tags`     | Base URL to prepend to each tag.                            |
 | `sort`        | `boolean`  | `false`     | Sort tags alphabetically; input order is preserved by default. |
 | `class`  | `string`   | `undefined` | Additional CSS classes, useful for [helper classes](/docs/helpers). |
 | `ariaLabel`   | `string`   | `'Tags'`    | Accessible label for the tag list.                          |
@@ -81,14 +81,14 @@ The following custom properties are available in the [default theme](/docs/theme
 
 ### Astro example (frontmatter metadata)
 
-<Tags tagList={["css", "astro", "basics"]} url="/tags" />
+<Tags tagList={["css", "astro", "basics"]} url="/blog/tags" />
 
 ```astro
 ---
 import Tags from '../components/Tags.astro';
 const { frontmatter } = Astro.props;
 ---
-<Tags tagList={frontmatter.tags} url="/tags" />
+<Tags tagList={frontmatter.tags} url="/blog/tags" />
 ```
 
 </li>
@@ -99,26 +99,26 @@ const { frontmatter } = Astro.props;
 
 <ul class="tags">
   <li>
-    <a href="/tags/css">css</a>
+    <a href="/blog/tags/css">css</a>
   </li>
   <li>
-    <a href="/tags/astro">astro</a>
+    <a href="/blog/tags/astro">astro</a>
   </li>
   <li>
-    <a href="/tags/basics">basics</a>
+    <a href="/blog/tags/basics">basics</a>
   </li>
 </ul>
 
 ```html
 <ul class="tags">
   <li>
-    <a href="/tags/css">css</a>
+    <a href="/blog/tags/css">css</a>
   </li>
   <li>
-    <a href="/tags/astro">astro</a>
+    <a href="/blog/tags/astro">astro</a>
   </li>
   <li>
-    <a href="/tags/basics">basics</a>
+    <a href="/blog/tags/basics">basics</a>
   </li>
 </ul>
 ```
@@ -130,26 +130,26 @@ const { frontmatter } = Astro.props;
 
 <ul class="tags tags-inline">
   <li>
-    <a href="/tags/css">css</a>
+    <a href="/blog/tags/css">css</a>
   </li>
   <li>
-    <a href="/tags/astro">astro</a>
+    <a href="/blog/tags/astro">astro</a>
   </li>
   <li>
-    <a href="/tags/basics">basics</a>
+    <a href="/blog/tags/basics">basics</a>
   </li>
 </ul>
 
 ```html
 <ul class="tags tags-inline">
   <li>
-    <a href="/tags/css">css</a>
+    <a href="/blog/tags/css">css</a>
   </li>
   <li>
-    <a href="/tags/astro">astro</a>
+    <a href="/blog/tags/astro">astro</a>
   </li>
   <li>
-    <a href="/tags/basics">basics</a>
+    <a href="/blog/tags/basics">basics</a>
   </li>
 </ul>
 ```

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -41,7 +41,7 @@ const { frontmatter } = Astro.props;
       {
         tags.map((tag) => (
           <li>
-            <a href={`/tags/${tag}`}>{tag}</a>
+            <a href={`/blog/tags/${tag}`}>{tag}</a>
           </li>
         ))
       }

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import { createMarkdownProcessor } from '@astrojs/markdown-remark';
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
 
 export async function getStaticPaths() {
   const allPosts = await getCollection('blog');

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,8 +1,8 @@
 ---
 import { getCollection } from 'astro:content';
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
 
-import Tags from '../../components/Tags.astro';
+import Tags from '../../../components/Tags.astro';
 
 const allPosts = await getCollection('blog');
 const tags = [...new Set(allPosts.map((post) => post.data.tags).flat())];


### PR DESCRIPTION
Closes #3

Moves `/tags` and `/tags/[tag]` to `/blog/tags` and `/blog/tags/[tag]`.

- Old URLs redirect via `astro.config.mjs` (static meta-refresh pages).
- Default tag-link props (`Tags.astro`, `ArticleCard.astro`), the footer link, and blog-post tag links updated; component docs examples updated to match.
- Relative import depth fixed in the moved pages.

**Why:** tags only apply to blog posts, and `Header.astro` marks the current nav section by first path segment — so tag pages now correctly highlight the **Blog** nav item (`aria-current="true"`), which was the original motivation in #3.

Verified in dev: redirect works, tag pages render, nav state correct; production build passes (101 pages, redirect pages emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)