### PR TITLE
Redesign the homepage as the first template demo

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "port": 4321
+    },
+    {
+      "name": "dev-4330",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--port", "4330"],
+      "port": 4330
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ All architectural detail is in the `agents/` directory — read these before mak
 
 ## Formatting
 
+- Never use em dashes in prose (site copy, docs, comments, commit messages). Use periods, commas, colons, or parentheses instead.
 - 2 spaces everywhere, including `.css` (enforced by `.editorconfig`).
 - Relative imports for all local Astro components.
 - JSX targets Preact (`jsxImportSource: "preact"` in `tsconfig.json`) — do not import from React.

--- a/src/components/_BaselineBadge.astro
+++ b/src/components/_BaselineBadge.astro
@@ -1,0 +1,27 @@
+---
+// Compact Baseline-status badge (homepage §4 showcase).
+// Same web-features dataset as _CanIUse.astro, badge only — receipts, not claims.
+import { features as webFeatures } from 'web-features';
+import baselineLimitedIcon from '../assets/icons/baseline-limited.svg?raw';
+import baselineNewlyIcon from '../assets/icons/baseline-newly.svg?raw';
+import baselineWidelyIcon from '../assets/icons/baseline-widely.svg?raw';
+
+interface Props {
+  // A web-features id, e.g. "cascade-layers", "light-dark"
+  feature: string;
+}
+
+const { feature } = Astro.props;
+const feat = (webFeatures as Record<string, any>)[feature];
+const baseline = feat?.status?.baseline ?? false; // 'high' | 'low' | false
+const year = feat?.status?.baseline_low_date?.split('-')[0];
+
+const icon = baseline === 'high' ? baselineWidelyIcon : baseline === 'low' ? baselineNewlyIcon : baselineLimitedIcon;
+const label = baseline === 'high' ? 'Baseline Widely available' : baseline === 'low' ? `Baseline ${year}` : 'Limited availability';
+const url = feat ? `https://github.com/web-platform-dx/web-features/blob/main/features/${feature}.yml` : undefined;
+---
+
+<a class={`baselineBadge baselineBadge-${baseline || 'limited'}`} href={url} target="_blank" rel="noopener noreferrer">
+  <Fragment set:html={icon} />
+  <span>{label}</span>
+</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,37 +1,377 @@
 ---
-import { Image } from 'astro:assets';
+import { Code } from 'astro:components';
 
 import BaseLayout from '../layouts/BaseLayout.astro';
-const title = 'The library for CSS lovers | mCSS';
-const header = 'mCSS';
-import mcssImg from '../assets/ui/mcss-logo.svg';
-import waterfallImg from '../assets/images/illustration-waterfall.svg?raw';
+import Section from '../components/Section.astro';
+import FeatureGrid from '../components/FeatureGrid.astro';
+import FeatureItem from '../components/FeatureItem.astro';
+import Card from '../components/Card.astro';
+import PricingCard from '../components/PricingCard.astro';
+import Testimonial from '../components/Testimonial.astro';
+import Faq from '../components/Faq.astro';
+import FaqItem from '../components/FaqItem.astro';
+import Field from '../components/Field.astro';
+import Pagination from '../components/Pagination.astro';
+import CopyButton from '../components/_CopyButton.jsx';
+import BaselineBadge from '../components/_BaselineBadge.astro';
+
+import githubIcon from '../assets/icons/social-github.svg?raw';
+import replayIcon from '../assets/icons/rotate-ccw.svg?raw';
+
+const title = 'mCSS: One class. Not forty.';
+const description =
+  'mCSS is a modern CSS framework and Astro component library for websites. Real CSS, one class per element, zero build step, MIT. You copy it, you own it.';
+
+const installSnippet = '<link rel="stylesheet" href="mcss.min.css">';
+
+// §5 diff panes, rendered with Shiki (github-dark) at build time.
+// Each list matches the overrides in page.home.css line for line.
+const themeDiffs = {
+  default: `/* settings.theme.default.css, as shipped */
+:root {
+  --heading-font: var(--display);
+  --text-color: light-dark(#23282e, #d6dbe1);
+  --card-bg-color: light-dark(#edeef1, #353c45);
+  --card-border-radius: 8px;
+  --card-shadow: var(--shadow-md);
+  --bt-primary-background-color: #0284c7;
+  --bt-primary-background-color-hover: #0ea5e9;
+  --bt-primary-border-color: #0284c7;
+  --bt-primary-border-color-hover: #0284c7;
+  --bt-border-radius: 8px;
+  --input-border-radius: 5px;
+  --link-color: light-dark(#0284c7, #38bdf8);
+}`,
+  wireframe: `/* wireframe: the entire diff */
+:root {
+  --heading-font: ui-rounded, "Arial Rounded MT Bold", Calibri, sans-serif;
+  --text-color: light-dark(#404040, #d4d4d4);
+  --card-bg-color: light-dark(#f5f5f5, #171717);
+  --card-border-radius: 0;
+  --card-shadow: none;
+  --bt-primary-background-color: #525252;
+  --bt-primary-background-color-hover: #737373;
+  --bt-primary-border-color: #525252;
+  --bt-primary-border-color-hover: #525252;
+  --bt-border-radius: 0;
+  --input-border-radius: 0;
+  --link-color: light-dark(#525252, #a3a3a3);
+}`,
+  sunset: `/* sunset: the entire diff */
+:root {
+  --heading-font: "Iowan Old Style", Georgia, serif;
+  --text-color: light-dark(#431407, #ffedd5);
+  --card-bg-color: light-dark(#fff7ed, #431407);
+  --card-border-radius: 16px;
+  --card-shadow: 0 8px 24px rgb(234 88 12 / 0.25);
+  --bt-primary-background-color: #ea580c;
+  --bt-primary-background-color-hover: #f97316;
+  --bt-primary-border-color: #ea580c;
+  --bt-primary-border-color-hover: #ea580c;
+  --bt-border-radius: 1e5px;
+  --input-border-radius: 1e5px;
+  --link-color: light-dark(#c2410c, #fb923c);
+}`,
+};
 ---
 
-<BaseLayout title={title} header={header} bodyClass="home">
-  <div class="wrap">
-    <section class="wrap_content wrap_content-fullBleed home_hero">
-      <h1>The framework that makes the cascade work for you.</h1>
-      <!-- <Image src={waterfallImg} width="800" alt="Illustration of a waterfall" /> -->
-      <Fragment set:html={waterfallImg} />
-      <ul>
-        <li>Easy</li>
-        <li>Fast</li>
-        <li>Scalable</li>
-        <li>Elegant</li>
+<BaseLayout title={title} bodyClass="home" frontmatter={{ description }}>
+  {/* §1: Hero */}
+  <section class="homeHero" aria-labelledby="homeHero-title">
+    <div class="homeHero_inner">
+      <div class="homeHero_copy">
+        <h1 id="homeHero-title">One class. Not&nbsp;forty.</h1>
+        <p class="homeHero_subhead">mCSS is a modern CSS framework and component library for websites. Real CSS, real markup, zero build step. Built on what browsers can finally do.</p>
+        <p class="homeHero_actions">
+          <a class="bt bt-lg bt-primary" href="/docs/start">Get started</a>
+          <a class="bt bt-lg" href="https://github.com/minimaldesign/mCSS"><Fragment set:html={githubIcon} />View on GitHub</a>
+        </p>
+        <p class="homeHero_fineprint">MIT licensed&ensp;·&ensp;No dependencies&ensp;·&ensp;It’s just CSS</p>
+      </div>
+
+      {/* The code morph. The animated block is decorative for AT; the srOnly
+          line below carries the argument. */}
+      <div class="homeMorph">
+        <div class="homeMorph_canvas" aria-hidden="true">
+          <span class="homeMorph_canvasLabel">output</span>
+          <button type="button" class="bt bt-primary" tabindex="-1">Demo button</button>
+        </div>
+        <div class="homeMorph_connector" aria-hidden="true"></div>
+
+        <figure class="homeMorph_editor" aria-hidden="true">
+          <div class="homeMorph_chrome"><i></i><i></i><i></i></div>
+          {/* The invisible sizer keeps the box at the "before" height at every
+              width, so the collapse never shifts layout. Syntax spans fake
+              Shiki's github-dark (the real thing can't tokenize around the
+              animation spans). */}
+          <div class="homeMorph_frame">
+            <pre class="homeMorph_code"><code>&lt;<span class="homeMorph_tag">button</span> <span class="homeMorph_attr">class</span>=<span class="homeMorph_str">"</span><span class="homeMorph_after">bt bt-primary</span><span class="homeMorph_g homeMorph_g-1"><span class="homeMorph_gt">bg-primary-600</span> </span><span class="homeMorph_g homeMorph_g-2"><span class="homeMorph_gt">px-4</span> </span><span class="homeMorph_g homeMorph_g-3"><span class="homeMorph_gt">py-3</span> </span><span class="homeMorph_g homeMorph_g-4"><span class="homeMorph_gt">text-sm</span> </span><span class="homeMorph_g homeMorph_g-5"><span class="homeMorph_gt">font-semibold</span> </span><span class="homeMorph_g homeMorph_g-6"><span class="homeMorph_gt">text-white</span> </span><span class="homeMorph_g homeMorph_g-7"><span class="homeMorph_gt">rounded-md</span> </span><span class="homeMorph_g homeMorph_g-8"><span class="homeMorph_gt">transition</span> </span><span class="homeMorph_g homeMorph_g-9"><span class="homeMorph_gt">duration-200</span> </span><span class="homeMorph_g homeMorph_g-10"><span class="homeMorph_gt">hover:bg-primary-700</span> </span><span class="homeMorph_g homeMorph_g-11"><span class="homeMorph_gt">focus-visible:ring-2</span> </span><span class="homeMorph_g homeMorph_g-12"><span class="homeMorph_gt">focus-visible:ring-offset-2</span> </span><span class="homeMorph_g homeMorph_g-13"><span class="homeMorph_gt">active:scale-95</span></span><span class="homeMorph_str">"</span>&gt;
+  Demo button
+&lt;/<span class="homeMorph_tag">button</span>&gt;</code></pre>
+            <pre class="homeMorph_code homeMorph_sizer"><code>&lt;button class="bg-primary-600 px-4 py-3 text-sm font-semibold text-white rounded-md transition duration-200 hover:bg-primary-700 focus-visible:ring-2 focus-visible:ring-offset-2 active:scale-95"&gt;
+  Demo button
+&lt;/button&gt;</code></pre>
+          </div>
+          <p class="homeMorph_counter"><span class="homeMorph_count"></span> characters</p>
+        </figure>
+
+        {/* Reduced-motion: static before/after with the final numbers */}
+        <div class="homeMorph_static" aria-hidden="true">
+          <p class="homeMorph_staticArrow">↓</p>
+          <pre class="homeMorph_code homeMorph_code-after"><code>&lt;<span class="homeMorph_tag">button</span> <span class="homeMorph_attr">class</span>=<span class="homeMorph_str">"</span><span class="homeMorph_keep">bt bt-primary</span><span class="homeMorph_str">"</span>&gt;
+  Demo button
+&lt;/<span class="homeMorph_tag">button</span>&gt;</code></pre>
+          <p class="homeMorph_staticCount">219 → 54 characters</p>
+        </div>
+
+        <p class="a11y-srOnly">Two mCSS classes replace forty utility classes: the same rendered button, from markup you can read.</p>
+
+        <button type="button" class="homeMorph_replay js-morphReplay"><Fragment set:html={replayIcon} />Replay</button>
+      </div>
+    </div>
+  </section>
+
+  {/* §2: Proof strip: the install is one line */}
+  <Section class="homeProof" data-testid="home-proof">
+    <div class="homeProof_inner homeReveal">
+      <div class="homeProof_install">
+        <Code code={installSnippet} lang="html" theme="github-dark" />
+        <CopyButton client:visible code={installSnippet} />
+      </div>
+      <p class="homeProof_caption">
+        That’s the install. Download <a href="https://github.com/minimaldesign/mCSS/blob/main/dist/mcss.min.css"><code>dist/mcss.min.css</code></a> or copy the source files. Every modern browser understands them as-is: no compiler, no config, no <code>node_modules</code>.
+      </p>
+      <ul class="homeProof_facts">
+        <li>~21 KB min+gzip</li>
+        <li>0 dependencies</li>
+        <li><a href="/docs/start#browser-support">Baseline 2024</a></li>
       </ul>
-      <!-- <Image src={mcssImg} width="300" alt="mCSS Logo" /> -->
-    </section>
-    <section class="wrap_content prose">
-      <h2>Embrace CSS true power</h2>
-      <p>Discover a CSS framework that honors the essence of the language rather than attempting to “fix” it. <strong>mCSS</strong> empowers front-end developers to harness the full potential of CSS with ease, efficiency, and elegance.</p>
-      <h2>Simplify your workflow</h2>
-      <p>Say goodbye to tedious tasks and hello to efficiency! With <strong>mCSS</strong>, you can dive into your projects within minutes. Since it’s built on pure CSS, there’s no steep learning curve—just seamless integration into your existing workflow.</p>
-      <h2>Versatile for any project</h2>
-      <p>Whether you’re creating a quick static HTML mockup, enhancing a legacy PHP application, or building a component-based React app, <strong>mCSS</strong> is your go-to solution. Its flexibility allows you to adapt it for virtually any project that utilizes CSS.</p>
-      <h2>Perfect for teams of all sizes</h2>
-      <p><strong>mCSS</strong> features a modular architecture designed for scalability, making it ideal for both small teams and large collaborative projects. Enjoy the benefits of organized code and effortless teamwork as you bring your projects to life.</p>
-    </section>
-    <p class="home_cta"><a class="bt bt-lg bt-primary" href="/docs/start">Get started in 10 mn or less</a></p>
-  </div>
+    </div>
+  </Section>
+
+  {/* §3: Philosophy */}
+  <Section class="homePhilosophy" variant="filled" eyebrow="Philosophy" title="Made for humans who write CSS" lede="CSS isn’t broken, and you don’t need to be protected from it. mCSS takes care of the tedious parts (resets, tokens, a sane cascade) and gets out of the way.">
+    <FeatureGrid class="homePillars homeReveal" cols={3}>
+      <FeatureItem title="It’s actual CSS.">
+        <svg slot="icon" viewBox="0 0 220 140" xmlns="http://www.w3.org/2000/svg" fill="none">
+          <path d="M88 24 C74 24 70 32 70 43 L70 55 C70 64 64 69 57 70 C64 71 70 76 70 85 L70 97 C70 108 74 116 88 116" stroke="#0ea5e9" stroke-width="10" stroke-linecap="round" />
+          <path d="M132 24 C146 24 150 32 150 43 L150 55 C150 64 156 69 163 70 C156 71 150 76 150 85 L150 97 C150 108 146 116 132 116" stroke="#7dd3fc" stroke-width="10" stroke-linecap="round" />
+          <circle cx="110" cy="58" r="7" fill="#0369a1" />
+          <circle cx="110" cy="84" r="7" fill="#0369a1" />
+        </svg>
+        No pseudo-syntax, no new mental model. If you know CSS, you already know mCSS, and everything you learn here works everywhere, forever.
+      </FeatureItem>
+      <FeatureItem title="The cascade is a feature.">
+        <svg slot="icon" viewBox="0 0 220 140" xmlns="http://www.w3.org/2000/svg" fill="none">
+          <path d="M110 20 L152 42 L110 64 L68 42 Z" stroke="#0ea5e9" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M68 70 L110 92 L152 70" stroke="#7dd3fc" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M68 98 L110 120 L152 98" stroke="#bae6fd" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        Native <code>@layer</code> keeps specificity conflicts from ever starting: anything you write outside mCSS’s layers wins automatically. No <code>!important</code>, no fighting your framework.
+      </FeatureItem>
+      <FeatureItem title="Markup you can read.">
+        <svg slot="icon" viewBox="0 0 220 140" xmlns="http://www.w3.org/2000/svg" fill="none">
+          <rect x="64" y="10" width="92" height="120" rx="10" fill="#e0f2fe" />
+          <rect x="80" y="28" width="32" height="7" rx="3.5" fill="#38bdf8" />
+          <path d="M94 56 L81 68 L94 80" stroke="#0369a1" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M126 56 L139 68 L126 80" stroke="#0369a1" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M116 51 L104 85" stroke="#0ea5e9" stroke-width="8" stroke-linecap="round" />
+          <rect x="80" y="100" width="60" height="7" rx="3.5" fill="#7dd3fc" />
+          <rect x="80" y="113" width="40" height="7" rx="3.5" fill="#bae6fd" />
+        </svg>
+        One semantic class per element. Your HTML describes what things <em>are</em>, and six months from now you’ll still understand it.
+      </FeatureItem>
+    </FeatureGrid>
+  </Section>
+
+  {/* §4: Modern CSS showcase */}
+  <Section class="homeShowcase" eyebrow="Modern CSS" title="Built on what browsers can do now" lede="The last few years quietly made CSS spectacular. mCSS is what a framework looks like when it’s designed after that happened.">
+    <ul class="homeShowcase_grid grid homeReveal" col="1" col-md="2" col-lg="3">
+      <li class="homeShowcase_card">
+        <h3 class="homeShowcase_name"><code>@layer</code></h3>
+        <p>The whole architecture. Import order stops mattering, and your overrides always win.</p>
+        <BaselineBadge feature="cascade-layers" />
+      </li>
+      <li class="homeShowcase_card homeShowcase_card-lightDark">
+        <h3 class="homeShowcase_name"><code>light-dark()</code></h3>
+        <p>Dark mode is one token file, not a parallel stylesheet.</p>
+        <label class="homeShowcase_mini">
+          <input class="toggle" type="checkbox" role="switch" />
+          <span>Flip this card’s <code>color-scheme</code></span>
+        </label>
+        <BaselineBadge feature="light-dark" />
+      </li>
+      <li class="homeShowcase_card">
+        <h3 class="homeShowcase_name"><code>:has()</code> &amp; nesting</h3>
+        <p>Components with zero specificity hacks, written the way you’d write them yourself.</p>
+        <BaselineBadge feature="has" />
+      </li>
+      <li class="homeShowcase_card">
+        <h3 class="homeShowcase_name"><code>@scope</code></h3>
+        <p>Prose styling that can’t leak into your components.</p>
+        <BaselineBadge feature="scope" />
+      </li>
+      <li class="homeShowcase_card">
+        <h3 class="homeShowcase_name">Scroll-driven animations</h3>
+        <p>The reading progress bar on this very site: pure CSS in modern browsers, a graceful fallback elsewhere.</p>
+        <BaselineBadge feature="scroll-driven-animations" />
+      </li>
+      <li class="homeShowcase_card">
+        <h3 class="homeShowcase_name">Three-tier tokens</h3>
+        <p>Raw scales → semantic theme → per-component properties. Change one value; the system follows.</p>
+        <BaselineBadge feature="custom-properties" />
+      </li>
+    </ul>
+    <p class="homeShowcase_kicker">Every technique is documented on the blog. The framework practices what it teaches. <a href="/blog">Read the blog →</a></p>
+  </Section>
+
+  {/* §5: Theming demo (radio + :has(), zero JS) */}
+  <Section class="homeThemer" variant="filled" eyebrow="Theming" title="Theme with variables, not variants" lede="Every color, size, and radius flows from one token file. Edit it and the whole system follows, light and dark.">
+    <fieldset class="homeThemer_switcher">
+      <legend class="a11y-srOnly">Pick a demo theme</legend>
+      <label class="homeThemer_swatch homeThemer_swatch-default">
+        <input type="radio" name="homeTheme" value="default" checked />
+        <i aria-hidden="true"></i><span>Default</span>
+      </label>
+      <label class="homeThemer_swatch homeThemer_swatch-wireframe">
+        <input type="radio" name="homeTheme" value="wireframe" />
+        <i aria-hidden="true"></i><span>Wireframe</span>
+      </label>
+      <label class="homeThemer_swatch homeThemer_swatch-sunset">
+        <input type="radio" name="homeTheme" value="sunset" />
+        <i aria-hidden="true"></i><span>Sunset</span>
+      </label>
+    </fieldset>
+
+    <div class="homeThemer_split homeReveal">
+      <div class="homeThemer_stage">
+        <Card title="Game night" subtitle="Friday 8pm at Maria’s place">
+          <p>Bring a snack and your best poker face. Newcomers welcome.</p>
+          <Fragment slot="actions">
+            <button type="button" class="bt">Details</button>
+            <button type="button" class="bt bt-primary">RSVP</button>
+          </Fragment>
+        </Card>
+        <div class="homeThemer_formRow">
+          <Field label="Email" name="homeThemer-email" type="email" placeholder="you@example.com" hint="We’ll never share it." />
+          <button type="button" class="bt bt-primary">Subscribe</button>
+        </div>
+      </div>
+
+      <div class="homeThemer_diff">
+        <div class="homeThemer_pane homeThemer_pane-default"><Code code={themeDiffs.default} lang="css" theme="github-dark" /></div>
+        <div class="homeThemer_pane homeThemer_pane-wireframe"><Code code={themeDiffs.wireframe} lang="css" theme="github-dark" /></div>
+        <div class="homeThemer_pane homeThemer_pane-sunset"><Code code={themeDiffs.sunset} lang="css" theme="github-dark" /></div>
+      </div>
+    </div>
+
+    {/* Below --lg the same panes live in a collapsed details */}
+    <details class="homeThemer_diffDetails">
+      <summary>Show the diff</summary>
+      <div class="homeThemer_pane homeThemer_pane-default"><Code code={themeDiffs.default} lang="css" theme="github-dark" /></div>
+      <div class="homeThemer_pane homeThemer_pane-wireframe"><Code code={themeDiffs.wireframe} lang="css" theme="github-dark" /></div>
+      <div class="homeThemer_pane homeThemer_pane-sunset"><Code code={themeDiffs.sunset} lang="css" theme="github-dark" /></div>
+    </details>
+
+    <p class="homeThemer_caption">Radio buttons and <code>:has()</code>: this demo runs on zero JavaScript.</p>
+  </Section>
+
+  {/* §6: Component gallery */}
+  <Section class="homeGallery" eyebrow="Component library" title="Components for real websites" lede="Header to footer: heroes, sections, feature grids, pricing, testimonials, FAQs, forms, article lists, pagination. Built for marketing sites, blogs, and docs. Ships as plain HTML or Astro, whichever you write.">
+    <ul class="homeGallery_grid homeReveal">
+      <li class="homeGallery_cell">
+        <div class="homeGallery_thumb" inert>
+          <Card title="Field notes" subtitle="Issue #12">
+            <p>A monthly dispatch on modern CSS, real-world markup, and the odd bird photo.</p>
+            <Fragment slot="actions"><button type="button" class="bt bt-primary">Read it</button></Fragment>
+          </Card>
+        </div>
+        <div class="homeGallery_meta"><span class="homeGallery_name">Card</span><span class="badge badge-success">Zero JS</span></div>
+        <a class="homeGallery_link" href="/components/card"><span class="a11y-srOnly">Card component documentation</span></a>
+      </li>
+      <li class="homeGallery_cell">
+        <div class="homeGallery_thumb" inert>
+          <PricingCard name="Indie" price="$0" period="/ forever" description="Everything, for everyone." features={['All components', 'Light & dark themes', 'MIT license']} ctaLabel="Copy the files" ctaHref="#" highlighted badge="MIT" />
+        </div>
+        <div class="homeGallery_meta"><span class="homeGallery_name">Pricing</span><span class="badge badge-success">Zero JS</span></div>
+        <a class="homeGallery_link" href="/components/pricing"><span class="a11y-srOnly">Pricing component documentation</span></a>
+      </li>
+      <li class="homeGallery_cell">
+        <div class="homeGallery_thumb" inert>
+          <Testimonial name="Ada Lindgren" role="Front-end lead">
+            <p>I stopped fighting my framework. There was nothing left to fight.</p>
+          </Testimonial>
+        </div>
+        <div class="homeGallery_meta"><span class="homeGallery_name">Testimonial</span><span class="badge badge-success">Zero JS</span></div>
+        <a class="homeGallery_link" href="/components/testimonial"><span class="a11y-srOnly">Testimonial component documentation</span></a>
+      </li>
+      <li class="homeGallery_cell">
+        <div class="homeGallery_thumb" inert>
+          <Faq>
+            <FaqItem question="Do I need a build step?" name="homeFaq" open>No. Link one file and start writing HTML.</FaqItem>
+            <FaqItem question="Can I override anything?" name="homeFaq">Yes: unlayered CSS always beats the framework.</FaqItem>
+          </Faq>
+        </div>
+        <div class="homeGallery_meta"><span class="homeGallery_name">FAQ</span><span class="badge badge-success">Zero JS</span></div>
+        <a class="homeGallery_link" href="/components/faq"><span class="a11y-srOnly">FAQ component documentation</span></a>
+      </li>
+      <li class="homeGallery_cell">
+        <div class="homeGallery_thumb" inert>
+          <div class="homeGallery_formDemo">
+            <Field label="Work email" name="homeGallery-email" type="email" placeholder="you@work.com" hint="One email a month, no noise." />
+            <button type="button" class="bt bt-primary">Sign up</button>
+          </div>
+        </div>
+        <div class="homeGallery_meta"><span class="homeGallery_name">Form field</span><span class="badge badge-success">Zero JS</span></div>
+        <a class="homeGallery_link" href="/components/field"><span class="a11y-srOnly">Field component documentation</span></a>
+      </li>
+      <li class="homeGallery_cell">
+        <div class="homeGallery_thumb homeGallery_thumb-wide" inert>
+          <Pagination currentPage={4} lastPage={9} baseUrl="/blog" />
+        </div>
+        <div class="homeGallery_meta"><span class="homeGallery_name">Pagination</span><span class="badge badge-success">Zero JS</span></div>
+        <a class="homeGallery_link" href="/components/pagination"><span class="a11y-srOnly">Pagination component documentation</span></a>
+      </li>
+    </ul>
+    <p class="homeGallery_kicker">Nearly everything is zero-JavaScript. The mobile menu and the dismissible banner are the exceptions, and they’re tiny.</p>
+    <div class="homeGallery_template homeReveal">
+      <h3>Start from a whole site, not a blank file.</h3>
+      <p>This site (the docs, the blog, and the page you’re reading) is built from the same library. <a href="/components/start">Browse the components →</a></p>
+    </div>
+  </Section>
+
+  {/* §7: Ownership */}
+  <Section class="homeOwn" variant="filled" eyebrow="Ownership" title="You own the code">
+    <div class="homeOwn_body homeReveal">
+      <p>mCSS isn’t a dependency. It’s a starting point. Copy the files into your project and edit them like the code you wrote yourself, because now it is. Styling disagreements end with you changing a line, not filing an issue.</p>
+      <p>MIT licensed. Versioned releases when you want to pull updates. No lock-in, because there’s nothing to be locked into.</p>
+    </div>
+    <ul class="homeOwn_facts homeReveal">
+      <li><strong>MIT</strong><span>Use it anywhere. Keep it forever.</span></li>
+      <li><strong>Versioned releases</strong><span>Pull updates when you choose to.</span></li>
+      <li><strong>One token file</strong><span>Edit <code>settings.tokens.css</code>, not <code>node_modules</code>.</span></li>
+    </ul>
+  </Section>
+
+  {/* §8: Final CTA */}
+  <Section class="homeCta" variant="primary" title="Give your CSS its cascade back" lede="Read the methodology, copy the files, ship something.">
+    <div class="section_actions">
+      <a class="bt bt-lg homeCta_btMain" href="/docs/start">Get started in 10 minutes</a>
+      <a class="bt bt-lg bt-outline-white" href="https://github.com/minimaldesign/mCSS"><Fragment set:html={githubIcon} />Star on GitHub</a>
+    </div>
+    <p class="homeCta_newsletter">Prefer email? <a href="https://mcss.ck.page/900e1d8f88" target="mailing-list">Join the mailing list</a>: new components and modern-CSS write-ups, no noise.</p>
+  </Section>
 </BaseLayout>
+
+{/* The one allowed JS nicety: restart the hero loop. */}
+<script>
+  const morph = document.querySelector('.homeMorph');
+  const replay = document.querySelector('.js-morphReplay');
+  if (morph && replay) {
+    replay.addEventListener('click', () => {
+      morph.classList.add('is-resetting');
+      void (morph as HTMLElement).offsetWidth;
+      morph.classList.remove('is-resetting');
+    });
+  }
+</script>

--- a/src/styles/site/page.home.css
+++ b/src/styles/site/page.home.css
@@ -1,162 +1,1010 @@
-.home {
-  h1,
-  h2 {
-    color: transparent;
-    background: linear-gradient(90deg, var(--primary-950), var(--primary-400));
-    background-clip: text;
-    text-fill-color: transparent;
+/* HOMEPAGE */
+
+/*
+  The homepage is the first template demo: every section is built from the v1
+  library (Section, FeatureGrid, Card, Field, badges) plus the page styles
+  below. Section numbers (§1 to §9) reference mcss-homepage-content-map.md.
+*/
+
+/* Poster-grade vertical rhythm (denser than the docs pages) */
+.home .section {
+  --section-spacing: var(--xl1);
+  @media (--lg) {
+    --section-spacing: var(--xxl1);
   }
 }
 
-:root:has(.root-theme:checked) .home {
-  h1,
-  h2 {
-    color: var(--primary-400);
+/* §3 to §6: narrow header, wide content. These blocks escape the wrap
+   column and center at up to 1150px. */
+.homePillars,
+.homeShowcase_grid,
+.homeThemer_split,
+.homeGallery_grid {
+  grid-column: 1 / -1;
+  width: 100%;
+  max-width: 1150px;
+  margin-inline: auto;
+  @media (--lg) {
+    padding-left: var(--sm3);
+    padding-right: var(--sm3);
   }
 }
 
-/* INDEX */
+/* Scroll reveal: one effect, used consistently. Decoration only; browsers
+   without scroll-driven animations simply show the content. */
+@media (--motionOK) {
+  @supports (animation-timeline: view()) {
+    .homeReveal,
+    .home .section_header {
+      animation: homeReveal linear both;
+      animation-timeline: view();
+      animation-range: entry 10% entry 40%;
+    }
+  }
+}
 
-.home_hero {
-  text-align: center;
-  margin: var(--lg1) 0;
+@keyframes homeReveal {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+}
+
+/* §1 HERO */
+
+.homeHero {
+  display: grid;
+  align-content: center;
+  min-height: calc(72svh - var(--header-height));
+  padding-block: var(--lg1) var(--sm3);
+  padding-inline: var(--sm1);
   @media (--md) {
-    margin-top: var(--xl3);
-    margin-bottom: var(--xl3);
+    padding-inline: var(--sm3);
   }
+}
 
+.homeHero_inner {
+  width: 100%;
+  max-width: 1150px;
+  margin-inline: auto;
+  display: grid;
+  gap: var(--lg3);
+  @media (--lg) {
+    grid-template-columns: minmax(0, 10fr) minmax(0, 9fr);
+    align-items: center;
+    gap: var(--xl2);
+  }
+}
+
+.homeHero_copy {
   h1 {
-    font-size: var(--display-md);
-    font-weight: var(--black);
+    /* Gradient-clipped text; light-dark() per stop keeps both themes AA
+       (postcss-mixins can't see display-gradient from another file).
+       fit-content, not max-content: max-content inflates the hero grid's
+       min-content size and overflows small viewports */
+    width: fit-content;
+    max-width: 100%;
+    color: transparent;
+    /* background-image longhand: preset-env's light-dark polyfill re-emits
+       shorthands after this rule, which would reset background-clip */
+    background-image: linear-gradient(
+      90deg,
+      light-dark(var(--primary-950), var(--primary-300)),
+      light-dark(var(--primary-500), var(--primary-500))
+    );
+    background-clip: text;
+    /* The gradient only paints the box; at line-height 1 the descenders
+       poke below it and vanish, so extend the box under the last line */
+    padding-bottom: 0.12em;
+    font-size: var(--display-lg);
     line-height: var(--leading-xs);
-    padding: var(--xs1);
     @media (--md) {
+      font-size: var(--display-mega);
+    }
+    @media (--lg) {
       font-size: var(--display-giga);
     }
   }
+}
 
-  /* prettier-ignore */
+.homeHero_subhead {
+  max-width: 38ch;
+  margin-top: var(--sm1);
+  font-size: var(--text-lg);
+  color: light-dark(var(--base-500), var(--base-400));
+  @media (--md) {
+    font-size: var(--text-xl);
+  }
+}
+
+.homeHero_actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--xs3);
+  margin-top: var(--md2);
+}
+
+.homeHero_fineprint {
+  margin-top: var(--sm1);
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  color: light-dark(var(--base-500), var(--base-400));
+}
+
+/* §1 THE CODE MORPH */
+
+/* Animated character counter (219 to 54). The unregistered fallback below
+   keeps the number correct in engines without @property (it just steps
+   instead of ticking). */
+@property --morph-n {
+  syntax: "<integer>";
+  inherits: true;
+  initial-value: 219;
+}
+
+.homeMorph {
+  display: flex;
+  flex-direction: column;
+  /* The editor surface is github-dark in both site themes */
+  --morph-duration: 20s;
+  --morph-strike: var(--no-400);
+  --morph-pulse: rgb(19 136 109 / 0.45);
+}
+
+/* The live render floats on the page; the dashed connector ties it to the
+   editor that produces it. The 1fr/auto/1fr grid keeps the button itself on
+   the center axis (where the connector is), label trailing to its left. */
+.homeMorph_canvas {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: var(--sm1);
+  padding-block: var(--xs2);
+}
+
+.homeMorph_canvasLabel {
+  justify-self: end;
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-lg);
+  text-transform: uppercase;
+  color: light-dark(var(--base-400), var(--base-500));
+}
+
+.homeMorph_connector {
+  align-self: center;
+  height: var(--md1);
+  border-left: var(--border-md) dashed light-dark(var(--base-300), var(--base-600));
+}
+
+/* The editor fakes Shiki's github-dark (colors below match the theme the §5
+   panes get from the real Shiki), in both site themes */
+.homeMorph_editor {
+  margin: 0;
+  padding: var(--sm3);
+  background-color: #24292e;
+  border: var(--border-sm) solid rgb(255 255 255 / 0.12);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  animation: morphFade var(--morph-duration) linear infinite;
+}
+
+.homeMorph_chrome {
+  display: flex;
+  gap: var(--xs2);
+  margin-bottom: var(--sm1);
+
+  i {
+    width: 10px;
+    height: 10px;
+    border-radius: var(--radius-round);
+    opacity: var(--o-4);
+    &:nth-child(1) { background: var(--no-300); }
+    &:nth-child(2) { background: var(--maybe-300); }
+    &:nth-child(3) { background: var(--yes-300); }
+  }
+}
+
+/* Both morph states share one grid cell; the hidden sizer (full "before"
+   text) reserves that state's height at every width, so CLS is ~0 */
+.homeMorph_frame {
+  display: grid;
+
+  > pre {
+    grid-area: 1 / 1;
+  }
+}
+
+.homeMorph_sizer {
+  visibility: hidden;
+}
+
+.homeMorph_code {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: var(--leading-xl);
+  color: #e1e4e8;
+  overflow-wrap: anywhere;
+}
+
+/* github-dark syntax roles */
+.homeMorph_tag { color: #85e89d; }
+.homeMorph_attr { color: #b392f0; }
+.homeMorph_str { color: #9ecbff; }
+
+/* Strike color channel: animated on the class span, painted only over the
+   class text (not its trailing space) by the inner span's gradient stripe,
+   which we can center on the glyphs (text-decoration draws too low). */
+@property --morph-strike-now {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: transparent;
+}
+
+.homeMorph_g {
+  color: #9ecbff;
+  animation: var(--morph-duration) linear infinite;
+}
+
+.homeMorph_gt {
+  background-image: linear-gradient(
+    to bottom,
+    transparent calc(54% - 1.5px),
+    var(--morph-strike-now) calc(54% - 1.5px) calc(54% + 1.5px),
+    transparent calc(54% + 1.5px)
+  );
+}
+
+.homeMorph_g-1 { animation-name: morphC1; }
+.homeMorph_g-2 { animation-name: morphC2; }
+.homeMorph_g-3 { animation-name: morphC3; }
+.homeMorph_g-4 { animation-name: morphC4; }
+.homeMorph_g-5 { animation-name: morphC5; }
+.homeMorph_g-6 { animation-name: morphC6; }
+.homeMorph_g-7 { animation-name: morphC7; }
+.homeMorph_g-8 { animation-name: morphC8; }
+.homeMorph_g-9 { animation-name: morphC9; }
+.homeMorph_g-10 { animation-name: morphC10; }
+.homeMorph_g-11 { animation-name: morphC11; }
+.homeMorph_g-12 { animation-name: morphC12; }
+.homeMorph_g-13 { animation-name: morphC13; }
+
+.homeMorph_after,
+.homeMorph_keep {
+  color: #9ecbff;
+  font-weight: var(--semi-bold);
+}
+
+.homeMorph_after {
+  font-size: 0;
+  opacity: 0;
+  border-radius: var(--radius-sm);
+  background-color: transparent;
+  animation: morphAfter var(--morph-duration) linear infinite;
+}
+
+.homeMorph_counter {
+  margin: var(--xs2) 0 0;
+  font-family: var(--mono);
+  font-size: var(--text-sm);
+  font-weight: var(--bold);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  color: #8b949e;
+}
+
+.homeMorph_count {
+  --morph-n: 219;
+  animation: morphCount var(--morph-duration) linear infinite;
+
+  &::after {
+    counter-reset: morphN calc(var(--morph-n));
+    content: counter(morphN);
+  }
+}
+
+.homeMorph_replay {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--xs1);
+  align-self: flex-end;
+  margin-top: var(--xs3);
+  padding: var(--xs1) var(--xs2);
+  border: none;
+  background: none;
+  font-size: var(--text-sm);
+  color: light-dark(var(--base-500), var(--base-400));
+  cursor: pointer;
+  transition: color var(--transition-fast);
+
   svg {
-    width: 800px;
-    margin: var(--md3) auto;
-
-    .cls-1 { fill: #082f49; }
-    .cls-2 { fill: #123750; }
-    .cls-3 { fill: #095b86; }
-    .cls-4 { fill: #0a314b; }
-    .cls-5 { fill: #0f354e; }
-    .cls-6 { fill: #143952; }
-    .cls-7 { fill: #35b3ed; }
-    .cls-8 { fill: #0d334d; }
-    .cls-9 { fill: #41b8ee; }
-    .cls-10{ fill: #1d6890; }
-    .cls-11{ fill: #86d6fc; }
-    .cls-12{ fill: #0369a1; }
-    .cls-13{ fill: #48bbee; }
-    .cls-14{ fill: #16638c; }
-    .cls-15{ fill: #2c7297; }
-    .cls-16{ fill: #226b92; }
-    .cls-17{ fill: #0d6fa5; }
-    .cls-18{ fill: #bce7fd; }
-    .cls-19{ fill: #cfeefe; }
-    .cls-20{ fill: #30b2ec; }
-    .cls-21{ fill: #11608a; }
-    .cls-22{ fill: #1272a7; }
-    .cls-23{ fill: #13618b; }
-    .cls-24{ fill: #3385b3; }
-    .cls-25{ fill: #32b2ec; }
-    .cls-26{ fill: #7dd3fc; }
-    .cls-27{ fill: #e1f2fe; }
-    .cls-28{ fill: #075985; }
-    .cls-29{ fill: #2f7499; }
-    .cls-30{ fill: #267eae; }
-    .cls-31{ fill: #b2e5fd; }
-    .cls-32{ fill: #2a7096; }
-    .cls-33{ fill: #d5f0fe; }
-    .cls-34{ fill: #92dafc; }
-    .cls-35{ fill: #93dafd; }
-    .cls-36{ fill: #086ca3; }
-    .cls-37{ fill: #10a6e9; }
-    .cls-38{ fill: #0ea5e9; }
-    .cls-39{ fill: #0e5e89; }
-    .cls-40{ fill: #1775a9; }
-    .cls-41{ fill: #13a7e9; }
-    .cls-42{ fill: #9addfd; }
-    .cls-43{ fill: #18658e; }
-    .cls-44{ fill: #066aa2; }
-    .cls-45{ fill: #1b668f; }
-    .cls-46{ fill: #b5e6fd; }
-    .cls-47{ fill: #fbfdff; }
-    .cls-48{ fill: #c7ebfd; }
-    .cls-49{ fill: #ebf7fe; }
-    .cls-50{ fill: #e5f4fe; }
-    .cls-51{ fill: #2bb0ec; }
-    .cls-52{ fill: #f0f9ff; }
-    .cls-53{ fill: #d2effe; }
-    .cls-54{ fill: #d4effe; }
-    .cls-55{ fill: #b4e5fd; }
-    .cls-56{ fill: #c2e9fd; }
-    .cls-57{ fill: #eff8fe; }
-    .cls-58{ fill: #2b81b0; }
-    .cls-59{ fill: #f5fbff; }
-    .cls-60{ fill: #e0f2fe; }
-    .cls-61{ fill: #c1e8fd; }
-    .cls-62{ fill: #e7f5fe; }
-    .cls-63{ fill: #80d4fc; }
-    .cls-64{ fill: #bae6fd; }
+    width: 14px;
+    height: 14px;
   }
 
-  ul {
-    display: flex;
-    justify-content: center;
-    padding: 0 var(--md1);
-    font-size: var(--text-lg);
-    font-weight: var(--bold);
-    @media (--md) {
-      font-size: var(--display-sm);
-    }
-    li {
-      &:nth-child(n + 2) {
-        &::before {
-          content: "•";
-          padding: 0 var(--xs2);
-          color: var(--primary-700);
-          @media (--md) {
-            padding-left: var(--xs3);
-            padding-right: var(--xs3);
-          }
-        }
-      }
-      &:nth-child(1) {
-        color: var(--primary-900);
-      }
-      &:nth-child(2) {
-        color: var(--primary-800);
-      }
-      &:nth-child(3) {
-        color: var(--primary-700);
-      }
-      &:nth-child(4) {
-        color: var(--primary-600);
-      }
-    }
+  &:hover {
+    color: var(--text-color);
   }
 }
 
-:root:has(.root-theme:checked) .home {
-  ul {
-    li {
-      &:nth-child(1),
-      &:nth-child(2),
-      &:nth-child(3),
-      &:nth-child(4) {
-        color: var(--primary-400);
-      }
-    }
-  }
+/* Reduced-motion after-state (hidden while the animation runs) */
+.homeMorph_static {
+  display: none;
 }
 
-.home_cta {
+.homeMorph_staticArrow {
+  margin: var(--xs3) 0;
   text-align: center;
-  margin: var(--lg3) 0 var(--xl3);
+  font-size: var(--text-xl);
+  color: light-dark(var(--base-400), var(--base-500));
+}
+
+.homeMorph_static .homeMorph_code {
+  padding: var(--sm3);
+  background-color: #24292e;
+  border: var(--border-sm) solid rgb(255 255 255 / 0.12);
+  border-radius: var(--radius-xl);
+}
+
+.homeMorph_staticCount {
+  margin: var(--xs2) 0 0;
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  text-align: right;
+  color: light-dark(var(--base-500), var(--base-400));
+}
+
+/* Hovering the editor pauses the loop (no focusables inside; keyboard users
+   get the replay button) */
+.homeMorph_editor:hover,
+.homeMorph_editor:hover :is(.homeMorph_g, .homeMorph_after, .homeMorph_count) {
+  animation-play-state: paused;
+}
+
+/* Replay: the page script toggles this class to restart every animation */
+.homeMorph.is-resetting :is(.homeMorph_editor, .homeMorph_g, .homeMorph_after, .homeMorph_count) {
+  animation-name: none;
+}
+
+@media (--motionNotOK) {
+  .homeMorph_editor,
+  .homeMorph_g,
+  .homeMorph_after,
+  .homeMorph_count {
+    animation: none;
+  }
+
+  /* Static before/after stacked with an arrow and the final numbers */
+  .homeMorph_counter,
+  .homeMorph_replay {
+    display: none;
+  }
+
+  .homeMorph_static {
+    display: block;
+  }
+}
+
+/* Timeline, per 20s loop: 1.2s settle, then each of the 13 classes gets a
+   0.7s slot (strike, fade, snap collapse) from 6% to 51.5%, survivors expand
+   and pulse at 52% to 62%, long hold, crossfade reset at the end. Slot i runs
+   A to B where A = 6 + 3.5(i-1) and B = A + 3.5 (percent). */
+
+@keyframes morphFade {
+  0%, 93.5% { opacity: 1; }
+  95.5%, 98.5% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+@keyframes morphC1 {
+  0%, 6% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  7%, 8.3% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  9.4% { opacity: 0; font-size: 1em; }
+  9.5%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC2 {
+  0%, 9.5% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  10.5%, 11.8% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  12.9% { opacity: 0; font-size: 1em; }
+  13%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC3 {
+  0%, 13% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  14%, 15.3% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  16.4% { opacity: 0; font-size: 1em; }
+  16.5%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC4 {
+  0%, 16.5% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  17.5%, 18.8% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  19.9% { opacity: 0; font-size: 1em; }
+  20%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC5 {
+  0%, 20% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  21%, 22.3% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  23.4% { opacity: 0; font-size: 1em; }
+  23.5%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC6 {
+  0%, 23.5% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  24.5%, 25.8% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  26.9% { opacity: 0; font-size: 1em; }
+  27%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC7 {
+  0%, 27% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  28%, 29.3% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  30.4% { opacity: 0; font-size: 1em; }
+  30.5%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC8 {
+  0%, 30.5% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  31.5%, 32.8% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  33.9% { opacity: 0; font-size: 1em; }
+  34%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC9 {
+  0%, 34% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  35%, 36.3% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  37.4% { opacity: 0; font-size: 1em; }
+  37.5%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC10 {
+  0%, 37.5% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  38.5%, 39.8% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  40.9% { opacity: 0; font-size: 1em; }
+  41%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC11 {
+  0%, 41% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  42%, 43.3% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  44.4% { opacity: 0; font-size: 1em; }
+  44.5%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC12 {
+  0%, 44.5% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  45.5%, 46.8% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  47.9% { opacity: 0; font-size: 1em; }
+  48%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphC13 {
+  0%, 48% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+  49%, 50.3% { opacity: 0.75; --morph-strike-now: var(--morph-strike); }
+  51.4% { opacity: 0; font-size: 1em; }
+  51.5%, 96% { opacity: 0; font-size: 0; }
+  96.5%, 100% { opacity: 1; font-size: 1em; --morph-strike-now: transparent; }
+}
+
+@keyframes morphAfter {
+  0%, 51.5% { font-size: 0; opacity: 0; background-color: transparent; }
+  52% { font-size: 1em; opacity: 0; }
+  53% { opacity: 1; background-color: var(--morph-pulse); }
+  62%, 96% { font-size: 1em; opacity: 1; background-color: transparent; }
+  96.5%, 100% { font-size: 0; opacity: 0; }
+}
+
+@keyframes morphCount {
+  0%, 8.8% { --morph-n: 219; }
+  9.5%, 12.3% { --morph-n: 204; }
+  13%, 15.8% { --morph-n: 199; }
+  16.5%, 19.3% { --morph-n: 194; }
+  20%, 22.8% { --morph-n: 186; }
+  23.5%, 26.3% { --morph-n: 172; }
+  27%, 29.8% { --morph-n: 161; }
+  30.5%, 33.3% { --morph-n: 150; }
+  34%, 36.8% { --morph-n: 139; }
+  37.5%, 40.3% { --morph-n: 126; }
+  41%, 43.8% { --morph-n: 105; }
+  44.5%, 47.3% { --morph-n: 84; }
+  48%, 50.8% { --morph-n: 56; }
+  51.5%, 52.2% { --morph-n: 41; }
+  53%, 96% { --morph-n: 54; }
+  96.5%, 100% { --morph-n: 219; }
+}
+
+/* §2 PROOF STRIP */
+
+.homeProof {
+  --section-spacing: var(--xl1);
+  padding-block-start: 0;
+}
+
+.homeProof_install {
+  position: relative;
+  width: fit-content;
+  max-width: 100%;
+  margin-inline: auto;
+}
+
+/* Shiki (github-dark) one-liner; padding leaves room for the copy button */
+.homeProof_install pre {
+  margin: 0;
+  padding: var(--sm1) var(--xl1) var(--sm1) var(--sm3);
+  font-size: var(--text-sm);
+  border-radius: var(--radius-lg);
+  @media (--md) {
+    font-size: var(--text-md);
+  }
+}
+
+.homeProof_caption {
+  max-width: 60ch;
+  margin: var(--sm3) auto 0;
+  text-align: center;
+  color: light-dark(var(--base-500), var(--base-400));
+}
+
+.homeProof_facts {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: var(--xs3) var(--md2);
+  margin: var(--sm3) 0 0;
+  padding: 0;
+  list-style: none;
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  color: light-dark(var(--base-500), var(--base-400));
+  @media (--sm-n-below) {
+    flex-direction: column;
+  }
+}
+
+/* §3 PHILOSOPHY */
+
+/* prettier-ignore */
+.homePillars {
+  @media (--md) {
+    --grid-tc: repeat(3, 1fr);
+  }
+
+  /* Large flat illustrations instead of the 48px icon box */
+  .featureItem_icon {
+    width: 100%;
+    height: 140px;
+    margin-bottom: var(--sm1);
+    background: none;
+    border-radius: 0;
+
+    svg {
+      width: auto;
+      height: 100%;
+      max-width: 100%;
+    }
+  }
+
+}
+
+/* §4 MODERN CSS SHOWCASE */
+
+.homeShowcase_grid {
+  /* margin-block only: the shared wide rule above owns margin-inline: auto */
+  margin-block: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.homeShowcase_card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--xs3);
+  padding: var(--sm3);
+  color: var(--text-color);
+  background-color: light-dark(var(--base-50), var(--base-900));
+  border-radius: var(--radius-lg);
+
+  p {
+    flex: 1;
+    margin: 0;
+  }
+}
+
+.homeShowcase_name {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: var(--text-lg);
+  font-weight: var(--bold);
+
+  code {
+    font-size: inherit;
+  }
+}
+
+/* The light-dark() card flips its own color-scheme: zero JS, fully contained */
+.homeShowcase_mini {
+  display: flex;
+  align-items: center;
+  gap: var(--xs2);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  --toggle-width: 36px;
+  --toggle-height: 20px;
+}
+
+:root:not(.theme-dark) .homeShowcase_card-lightDark:has(input:checked) {
+  color-scheme: dark;
+}
+
+:root.theme-dark .homeShowcase_card-lightDark:has(input:checked) {
+  color-scheme: light;
+}
+
+.homeShowcase_kicker {
+  margin-top: var(--lg1);
+  text-align: center;
+  color: light-dark(var(--base-500), var(--base-400));
+}
+
+/* Baseline badge (see _BaselineBadge.astro) */
+
+.baselineBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--xs2);
+  font-size: var(--text-xs);
+  color: light-dark(var(--base-500), var(--base-400));
+  text-decoration: none;
+
+  svg {
+    width: 22px;
+    height: auto;
+    flex: none;
+  }
+
+  &:hover span {
+    color: var(--link-color);
+    text-decoration: underline;
+  }
+}
+
+/* §5 THEMING DEMO */
+
+.homeThemer_switcher {
+  display: flex;
+  justify-content: center;
+  gap: var(--md2);
+  margin: 0 0 var(--md2);
+  padding: 0;
+  border: none;
+}
+
+.homeThemer_swatch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--xs2);
+  font-size: var(--text-sm);
+  cursor: pointer;
+
+  input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  i {
+    width: var(--md1);
+    height: var(--md1);
+    border-radius: var(--radius-round);
+    border: var(--border-md) solid var(--theme-border-color);
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  }
+
+  input:checked ~ i {
+    border-color: var(--text-color);
+    box-shadow: 0 0 0 2px var(--body-background-color) inset;
+  }
+
+  input:focus-visible ~ i {
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
+  }
+}
+
+.homeThemer_swatch-default i { background: var(--primary-500); }
+.homeThemer_swatch-wireframe i { background: #a3a3a3; }
+.homeThemer_swatch-sunset i { background: #ea580c; }
+
+.homeThemer_split {
+  display: grid;
+  gap: var(--md2);
+  @media (--lg) {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.homeThemer_stage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--md2);
+  padding: var(--md2);
+  background-color: light-dark(var(--base-0), var(--base-950));
+  border: var(--border-sm) solid var(--theme-border-color);
+  border-radius: var(--radius-lg);
+}
+
+.homeThemer_formRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sm1);
+
+  .bt {
+    align-self: flex-start;
+  }
+}
+
+/* Demo themes: each override list below matches its diff pane exactly.
+   Semantic tokens only; that's the theming API. */
+
+.homeThemer:has(input[value="wireframe"]:checked) .homeThemer_stage {
+  --heading-font: ui-rounded, "Arial Rounded MT Bold", Calibri, sans-serif;
+  --text-color: light-dark(#404040, #d4d4d4);
+  --card-bg-color: light-dark(#f5f5f5, #171717);
+  --card-border-radius: 0;
+  --card-shadow: none;
+  --bt-primary-background-color: #525252;
+  --bt-primary-background-color-hover: #737373;
+  --bt-primary-border-color: #525252;
+  --bt-primary-border-color-hover: #525252;
+  --bt-border-radius: 0;
+  --input-border-radius: 0;
+  --link-color: light-dark(#525252, #a3a3a3);
+}
+
+.homeThemer:has(input[value="sunset"]:checked) .homeThemer_stage {
+  --heading-font: "Iowan Old Style", Georgia, serif;
+  --text-color: light-dark(#431407, #ffedd5);
+  --card-bg-color: light-dark(#fff7ed, #431407);
+  --card-border-radius: 16px;
+  --card-shadow: 0 8px 24px rgb(234 88 12 / 0.25);
+  --bt-primary-background-color: #ea580c;
+  --bt-primary-background-color-hover: #f97316;
+  --bt-primary-border-color: #ea580c;
+  --bt-primary-border-color-hover: #ea580c;
+  --bt-border-radius: 1e5px;
+  --input-border-radius: 1e5px;
+  --link-color: light-dark(#c2410c, #fb923c);
+}
+
+/* Diff panes: Shiki (github-dark) output, one pane per theme */
+
+.homeThemer_pane {
+  display: none;
+
+  pre {
+    margin: 0;
+    padding: var(--sm3);
+    font-size: var(--text-md);
+    line-height: var(--leading-xl);
+    border-radius: var(--radius-lg);
+    overflow-x: auto;
+  }
+}
+
+.homeThemer:has(input[value="default"]:checked) .homeThemer_pane-default,
+.homeThemer:has(input[value="wireframe"]:checked) .homeThemer_pane-wireframe,
+.homeThemer:has(input[value="sunset"]:checked) .homeThemer_pane-sunset {
+  display: block;
+}
+
+/* Desktop: diff always visible. Mobile: collapsed details (same panes). */
+.homeThemer_diff {
+  display: none;
+  @media (--lg) {
+    display: block;
+  }
+}
+
+.homeThemer_diffDetails {
+  @media (--lg) {
+    display: none;
+  }
+
+  summary {
+    cursor: pointer;
+    font-weight: var(--semi-bold);
+  }
+
+  .homeThemer_pane {
+    margin-top: var(--sm1);
+  }
+}
+
+.homeThemer_caption {
+  margin-top: var(--sm3);
+  text-align: center;
+  font-size: var(--text-sm);
+  color: light-dark(var(--base-500), var(--base-400));
+}
+
+/* §6 COMPONENT GALLERY */
+
+.homeGallery_grid {
+  display: grid;
+  gap: var(--sm3);
+  margin-block: 0;
+  padding: 0;
+  list-style: none;
+  @media (--md) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (--lg) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.homeGallery_cell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.homeGallery_thumb {
+  flex: 1;
+  display: grid;
+  align-items: center;
+  padding: var(--sm3);
+  background-color: light-dark(var(--base-50), var(--base-900));
+  border: var(--border-sm) solid var(--theme-border-color);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color var(--transition-fast);
+  zoom: 0.85;
+}
+
+.homeGallery_cell:hover .homeGallery_thumb {
+  border-color: var(--link-color);
+}
+
+/* Wide component demos (pagination) shrink further to fit their cell */
+.homeGallery_thumb-wide {
+  zoom: 0.62;
+  justify-items: center;
+}
+
+.homeGallery_meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: var(--xs3);
+}
+
+.homeGallery_name {
+  font-weight: var(--semi-bold);
+}
+
+.homeGallery_link {
+  position: absolute;
+  inset: 0;
+  z-index: var(--z-1);
+  border-radius: var(--radius-lg);
+}
+
+.homeGallery_formDemo {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sm1);
+
+  .bt {
+    align-self: flex-start;
+  }
+}
+
+.homeGallery_kicker {
+  margin-top: var(--md2);
+  text-align: center;
+  color: light-dark(var(--base-500), var(--base-400));
+}
+
+.homeGallery_template {
+  margin-top: var(--xl1);
+  text-align: center;
+
+  p {
+    max-width: 55ch;
+    margin-inline: auto;
+    color: light-dark(var(--base-500), var(--base-400));
+  }
+}
+
+/* §7 OWNERSHIP: the exhale before the CTA */
+
+.homeOwn {
+  --section-spacing: var(--xl1);
+}
+
+.homeOwn_body {
+  max-width: 55ch;
+  margin-inline: auto;
+
+  p + p {
+    margin-top: var(--sm1);
+  }
+}
+
+.homeOwn_facts {
+  display: grid;
+  gap: var(--sm3);
+  max-width: 720px;
+  margin: var(--lg3) auto 0;
+  padding: 0;
+  list-style: none;
+  text-align: center;
+  @media (--md) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  li {
+    display: flex;
+    flex-direction: column;
+    gap: var(--xs1);
+  }
+
+  strong {
+    font-size: var(--text-lg);
+  }
+
+  span {
+    font-size: var(--text-sm);
+    color: light-dark(var(--base-500), var(--base-400));
+  }
+}
+
+/* §8 FINAL CTA: full-bleed #2, the second and last gradient */
+
+.homeCta {
+  --section-spacing: var(--xl2);
+  background: linear-gradient(105deg, var(--primary-950), var(--primary-600));
+
+  .section_header {
+    margin-bottom: var(--md2);
+  }
+}
+
+.homeCta_btMain {
+  --bt-color: var(--primary-700);
+  --bt-color-hover: var(--primary-600);
+  --bt-background-color: var(--base-0);
+  --bt-background-color-hover: var(--primary-50);
+  --bt-border-color: var(--base-0);
+  --bt-border-color-hover: var(--base-0);
+}
+
+.homeCta_newsletter {
+  margin-top: var(--md2);
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--primary-100);
+
+  a {
+    color: var(--base-0);
+  }
 }


### PR DESCRIPTION
Rebuilds the homepage against `mcss-homepage-content-map.md` and `mcss-homepage-design-brief.md`, dogfooding the v1 component library end to end. Reviewed and iterated with Yann over three feedback rounds.

## Sections

1. **Hero**: "One class. Not forty." with a pure-CSS code morph: a 20s loop deletes 13 utility classes one at a time (glyph-centered strike via a registered custom property and a gradient stripe, so it never crosses trailing spaces), leaving `bt bt-primary`. Live character counter (219 to 54, real counts) via `@property` + `counter-reset`. A hidden sizer reserves the before-state height so CLS stays at 0. The floating demo button (labeled "output", never CTA copy) connects to the editor with a dashed line. Reduced motion gets a static before/after. Replay button is the page's only JS beyond the theme toggle.
2. **Proof strip**: the one-line install, Shiki-highlighted (`github-dark`), with copy button and receipts (~21 KB min+gzip, 0 dependencies, Baseline 2024).
3. **Philosophy**: three horizontal pillars with flat minimal illustrations.
4. **Modern CSS showcase**: six cards with live Baseline badges (new `_BaselineBadge.astro` over the web-features dataset); the `light-dark()` card flips its own `color-scheme` with zero JS.
5. **Theming demo**: radio + `:has()`, zero JS, three themes (default / wireframe / sunset), `github-dark` Shiki diff panes that match the applied overrides line for line.
6. **Component gallery**: live inert-scaled thumbnails linking to docs pages, Zero JS badges.
7. **Ownership**, 8. **gradient CTA banner**, 9. existing footer.

Content blocks in sections 3 to 6 escape the wrap column to 1150px while headers stay at 70ch. Both themes verified at 360/768/1024/1440, no horizontal overflow, heading outline clean, keyboard path intact, production build green.

Also documents the no-em-dashes rule in CLAUDE.md and adds a port-4330 dev server config to launch.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)