### PR TITLE
Add machine-readable docs for AI agents

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,12 @@
       "port": 4321
     },
     {
+      "name": "preview-4331",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview", "--", "--port", "4331"],
+      "port": 4331
+    },
+    {
       "name": "dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],

--- a/package.json
+++ b/package.json
@@ -36,13 +36,5 @@
     "postcss-import": "^16.1.1",
     "stylelint": "^17.14.0",
     "typescript": "^5.9.3"
-  },
-  "files": [
-    "dist"
-  ],
-  "style": "dist/mcss.css",
-  "exports": {
-    ".": "./dist/mcss.css",
-    "./css/*": "./dist/css/*"
   }
 }

--- a/src/components/NavDocs.astro
+++ b/src/components/NavDocs.astro
@@ -12,6 +12,7 @@ const subSections = [
   ['elements', 'HTML Elements'],
   ['global', 'Global Styles'],
   ['helpers', 'Helpers'],
+  ['ai', 'AI Agents'],
 ];
 ---
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,6 +25,8 @@ const docsCollection = defineCollection({
   loader: glob({ pattern: "**/[^_]*.{md,mdx}", base: "./src/content/docs" }),
   schema: z.object({
     title: z.string(),
+    // One-line summary surfaced in /llms.txt
+    description: z.string().optional(),
     lastUpdate: z.date(),
     version: z.number(),
   }),

--- a/src/content/docs/ai.mdx
+++ b/src/content/docs/ai.mdx
@@ -1,0 +1,90 @@
+---
+title: "AI Agents"
+description: "Machine-readable docs (llms.txt, markdown twins) and a ready-to-paste rules block for coding agents"
+lastUpdate: 2026-07-19
+version: 0.1
+---
+
+<section class="prose">
+
+mCSS is built to be easy for AI coding agents (Claude Code, Cursor, Copilot, and friends) to work with. The docs are available in machine-readable form, and this page includes a rules block you can paste into your project's agent instructions so generated markup is idiomatic mCSS instead of a plausible-looking guess.
+
+</section>
+
+## Machine-readable docs
+
+<section class="prose">
+
+Three things exist specifically for agents:
+
+- **[/llms.txt](/llms.txt)**: an index of every docs and components page with one-line descriptions, following the [llms.txt](https://llmstxt.org) convention. Most agent tooling checks for this automatically.
+- **[/llms-full.txt](/llms-full.txt)**: the entire reference (docs and all components) concatenated into a single markdown file. Point an agent here when it needs the whole framework in one fetch.
+- **Markdown twins**: every docs and components page is also served as plain markdown at the same URL with `.md` appended. For example, [/docs/tokens.md](/docs/tokens.md) or [/components/card.md](/components/card.md). These are a fraction of the size of the HTML pages and contain no site chrome.
+
+If you tell your agent one thing, tell it this: fetch the `.md` URLs, not the HTML.
+
+</section>
+
+## Add mCSS rules to your agent instructions
+
+<section class="prose">
+
+Paste the block below into your project's `CLAUDE.md`, `AGENTS.md`, or equivalent. It compresses the conventions that matter most when writing mCSS markup and CSS on top of it.
+
+</section>
+
+````md
+## mCSS conventions
+
+This project uses mCSS (https://mcss.dev), a copy-it-you-own-it CSS framework.
+The framework files live in this repo, not in node_modules; treat them as
+project code, not as an immutable dependency.
+Full reference: https://mcss.dev/llms-full.txt
+Per-page markdown docs: append `.md` to any docs or components URL
+(e.g. https://mcss.dev/components/card.md).
+
+### Class naming (BEM-like, different separators)
+
+- Block: `.componentName` (camelCase for multi-word names)
+- Element: `.componentName_element` (single underscore; chains may nest as deep
+  as the block's own structure needs)
+- Modifier: `.componentName-modifier` (single hyphen), for build-time variants
+- State: `.is-*` (`.is-active`, `.is-open`), only for things that change at
+  runtime, always scoped inside the block
+- Prefer styling ARIA attributes over inventing state classes when one exists:
+  `[aria-current]`, `[aria-expanded="true"]`, `[aria-disabled="true"]`
+
+### Never couple classes from different components
+
+A selector must only contain classes from its own block. Never write a selector
+that reaches into another component (`.myPage .card_title` is banned). To style
+a component from outside: mix your own class onto its root in the markup and
+style that, or set the component's theme tokens (`--card-*`, `--bt-*`, ...) on
+your own hook class. Bare HTML tags, `.is-*`, and ARIA selectors are fine
+inside your own block.
+
+### Customization (you own the files)
+
+- Customize by editing the framework files directly, tokens first: change
+  `settings.tokens.css` values (colors, type, spacing) before touching
+  component CSS.
+- Component tokens follow `--component-part-property`, longhand, kebab-case:
+  `--bt-background-color-hover`, `--notice-border-width`. No abbreviations.
+- Prefer semantic feedback tokens (`--success-*`, `--danger-*`, `--warning-*`).
+
+### Cascade model (native @layer)
+
+- The framework lives in cascade layers; your unlayered project CSS beats all
+  of it by design. Never add `!important` to win against the framework.
+- The exception: helper classes (`help.*` files, e.g. spacing/color/typography
+  utilities) carry `!important` and beat everything, like inline styles.
+- Never use `transition: all`; list the properties that actually animate.
+````
+
+## MCP and tooling
+
+<section class="prose">
+
+There is no mCSS MCP server yet. For now, `llms-full.txt` plus the rules block above is the recommended setup. If your agent supports fetching URLs at runtime, the markdown twins are the cheapest way to pull a single component's markup reference into context.
+
+</section>

--- a/src/content/docs/elements.mdx
+++ b/src/content/docs/elements.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HTML Elements"
+description: "Default styles for bare HTML elements: text, forms, media, tables"
 lastUpdate: 2024-08-27
 version: 0.1
 ---

--- a/src/content/docs/global.mdx
+++ b/src/content/docs/global.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Global Styles"
+description: "Structural patterns: grid, layout, prose, wrap, and accessibility utilities"
 lastUpdate: 2024-09-09
 version: 1.0
 ---

--- a/src/content/docs/helpers.mdx
+++ b/src/content/docs/helpers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Helpers"
+description: "Utility classes (spacing, color, typography) that override everything via !important"
 lastUpdate: 2024-09-05
 version: 0.1
 ---

--- a/src/content/docs/media-queries.mdx
+++ b/src/content/docs/media-queries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Media Queries"
+description: "Breakpoints and custom media queries used across the framework"
 lastUpdate: 2024-08-13
 version: 0.1
 ---

--- a/src/content/docs/reset.mdx
+++ b/src/content/docs/reset.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reset"
+description: "The opinionated CSS reset in the base layer"
 lastUpdate: 2024-09-09
 version: 1.0
 ---

--- a/src/content/docs/start.mdx
+++ b/src/content/docs/start.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+description: "Copy mCSS into your project and learn the methodology: file structure, class syntax, components"
 lastUpdate: 2024-09-17T22:06:48-07:00
 version: 0.9
 ---

--- a/src/content/docs/themes.mdx
+++ b/src/content/docs/themes.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Themes"
+description: "Theme tokens: semantic aliases over raw tokens, plus light and dark themes"
 lastUpdate: 2024-08-07
 version: 0.1
 ---

--- a/src/content/docs/tokens.mdx
+++ b/src/content/docs/tokens.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tokens"
+description: "Design tokens: the CSS custom properties for color, typography, spacing, and more that customize the framework"
 lastUpdate: 2024-08-07
 version: 0.1
 ---

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,7 +6,7 @@ import logoImg from '../assets/ui/mcss-logo.png';
 import SiteHeader from '../components/SiteHeader.astro';
 import SiteFooter from '../components/SiteFooter.astro';
 
-const { title, bodyClass, frontmatter } = Astro.props;
+const { title, bodyClass, frontmatter, markdownHref } = Astro.props;
 
 const headDescription = (frontmatter?.description ? frontmatter.description.slice(0, 149) + (frontmatter.description.length > 149 ? '…' : '') : '') || 'The CSS framework for CSS lovers.';
 const headImage = `${Astro.url.origin}${logoImg.src.split('?')[0]}`;
@@ -46,6 +46,7 @@ const headImage = `${Astro.url.origin}${logoImg.src.split('?')[0]}`;
 
     {/* SEO & Misc */}
     <link rel="canonical" href={Astro.url} />
+    {markdownHref && <link rel="alternate" type="text/markdown" href={markdownHref} />}
     <meta name="msapplication-TileColor" content="#0ea5e9" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="generator" content={Astro.generator} />

--- a/src/layouts/DocsComponentsLayout.astro
+++ b/src/layouts/DocsComponentsLayout.astro
@@ -6,9 +6,10 @@ import Toc from '../components/Toc.astro';
 import arrow from '../assets/icons/arrow-right-small.svg?raw';
 
 const { frontmatter } = Astro.props;
+const markdownHref = Astro.url.pathname.replace(/\/$/, '') + '.md';
 ---
 
-<BaseLayout title={`${frontmatter.title} | mCSS Documentation`} bodyClass="layout layout-sidebar">
+<BaseLayout title={`${frontmatter.title} | mCSS Documentation`} bodyClass="layout layout-sidebar" frontmatter={frontmatter} markdownHref={markdownHref}>
   <aside class="layout_content_aside">
     <NavComponents />
   </aside>

--- a/src/layouts/DocsPostLayout.astro
+++ b/src/layouts/DocsPostLayout.astro
@@ -6,9 +6,10 @@ import Toc from '../components/Toc.astro';
 import arrow from '../assets/icons/arrow-right-small.svg?raw';
 
 const { frontmatter } = Astro.props;
+const markdownHref = Astro.url.pathname.replace(/\/$/, '') + '.md';
 ---
 
-<BaseLayout title={`${frontmatter.title} | mCSS Documentation`} bodyClass="layout layout-sidebar">
+<BaseLayout title={`${frontmatter.title} | mCSS Documentation`} bodyClass="layout layout-sidebar" frontmatter={frontmatter} markdownHref={markdownHref}>
   <aside class="layout_content_aside">
     <NavDocs />
   </aside>

--- a/src/pages/components/[slug].md.js
+++ b/src/pages/components/[slug].md.js
@@ -1,0 +1,16 @@
+import { getCollection } from "astro:content";
+import { pageMarkdown, markdownResponse } from "../../scripts/llms";
+
+// Markdown twin of every components page: /components/<slug>.md
+
+export async function getStaticPaths() {
+  const entries = await getCollection("components");
+  return entries.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+
+export async function GET({ props, site }) {
+  return markdownResponse(pageMarkdown(props.entry, "components", site));
+}

--- a/src/pages/docs/[slug].md.js
+++ b/src/pages/docs/[slug].md.js
@@ -1,0 +1,16 @@
+import { getCollection } from "astro:content";
+import { pageMarkdown, markdownResponse } from "../../scripts/llms";
+
+// Markdown twin of every docs page: /docs/<slug>.md
+
+export async function getStaticPaths() {
+  const entries = await getCollection("docs");
+  return entries.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+
+export async function GET({ props, site }) {
+  return markdownResponse(pageMarkdown(props.entry, "docs", site));
+}

--- a/src/pages/llms-full.txt.js
+++ b/src/pages/llms-full.txt.js
@@ -1,0 +1,26 @@
+import { getCollection } from "astro:content";
+import { sortDocs, sortComponents, pageMarkdown, markdownResponse } from "../scripts/llms";
+
+// /llms-full.txt: the entire docs and components reference as one markdown file,
+// so an agent can load the whole framework reference in a single fetch.
+
+export async function GET(context) {
+  const site = context.site;
+  const docs = sortDocs(await getCollection("docs"));
+  const components = sortComponents(await getCollection("components"));
+
+  const pages = [
+    ...docs.map((entry) => pageMarkdown(entry, "docs", site)),
+    ...components.map((entry) => pageMarkdown(entry, "components", site)),
+  ];
+
+  const text = [
+    "# mCSS: full reference",
+    "",
+    "> mCSS is a modern CSS framework and component library for websites: real CSS, real markup, zero build step, built on native cascade layers. It is not a dependency; you copy the files into your project and own them. This file concatenates every docs and components page. A per-page index is at /llms.txt.",
+    "",
+    pages.join("\n\n---\n\n"),
+  ].join("\n");
+
+  return markdownResponse(text);
+}

--- a/src/pages/llms.txt.js
+++ b/src/pages/llms.txt.js
@@ -1,0 +1,46 @@
+import { getCollection } from "astro:content";
+import { sortDocs, sortComponents, pageUrl, markdownResponse } from "../scripts/llms";
+
+// /llms.txt: index of the machine-readable docs (llmstxt.org format).
+
+export async function GET(context) {
+  const site = context.site;
+  const docs = sortDocs(await getCollection("docs"));
+  const components = sortComponents(await getCollection("components"));
+
+  const docLine = (entry) => {
+    const url = pageUrl(site, "docs", entry.id, ".md");
+    const description = entry.data.description;
+    return `- [${entry.data.title}](${url})${description ? `: ${description}` : ""}`;
+  };
+
+  const componentLine = (entry) => {
+    const url = pageUrl(site, "components", entry.id, ".md");
+    const label = entry.data.type === "atom" ? " (atom)" : "";
+    return `- [${entry.data.title}](${url})${label}`;
+  };
+
+  const text = [
+    "# mCSS",
+    "",
+    "> mCSS is a modern CSS framework and component library for websites: real CSS, real markup, zero build step, built on native cascade layers. It is not a dependency; you copy the files into your project and own them, editing them directly (starting with settings.tokens.css).",
+    "",
+    "Every docs and components page has a markdown twin at the same URL with `.md` appended (e.g. /docs/tokens.md). Fetch those instead of the HTML pages. The complete reference in a single file is at /llms-full.txt.",
+    "",
+    "## Docs",
+    "",
+    ...docs.map(docLine),
+    "",
+    "## Components",
+    "",
+    ...components.map(componentLine),
+    "",
+    "## Optional",
+    "",
+    `- [Blog](${new URL("/blog", site).href}): release notes and articles`,
+    `- [Source](https://github.com/minimaldesign/mCSS): copy dist/mcss.min.css as a drop-in, dist/css/ for individual files, or src/styles/framework/ if you run PostCSS yourself`,
+    "",
+  ].join("\n");
+
+  return markdownResponse(text);
+}

--- a/src/scripts/llms.js
+++ b/src/scripts/llms.js
@@ -1,0 +1,82 @@
+// Shared helpers for the machine-readable docs endpoints:
+// /llms.txt, /llms-full.txt, and the .md twin of every docs/components page.
+
+// Docs pages in reading order (mirrors the NavDocs sidebar).
+export const DOCS_ORDER = [
+  "start",
+  "tokens",
+  "media-queries",
+  "themes",
+  "reset",
+  "elements",
+  "global",
+  "helpers",
+  "ai",
+];
+
+export function sortDocs(entries) {
+  return [...entries].sort(
+    (a, b) => DOCS_ORDER.indexOf(a.id) - DOCS_ORDER.indexOf(b.id),
+  );
+}
+
+// Components: intro first, then atoms, then components, alphabetical within each group.
+const COMPONENT_TYPE_ORDER = ["intro", "atom", "component"];
+
+export function sortComponents(entries) {
+  return [...entries].sort((a, b) => {
+    const typeDiff =
+      COMPONENT_TYPE_ORDER.indexOf(a.data.type) -
+      COMPONENT_TYPE_ORDER.indexOf(b.data.type);
+    return typeDiff !== 0 ? typeDiff : a.id.localeCompare(b.id);
+  });
+}
+
+// Strip MDX build noise (imports, MDX comments, docs-site prose wrappers) so the
+// body reads as plain markdown. Lines inside code fences are never touched.
+export function cleanMdxBody(body) {
+  const lines = body.split("\n");
+  const out = [];
+  let inFence = false;
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      out.push(line);
+      continue;
+    }
+    if (inFence) {
+      out.push(line);
+      continue;
+    }
+    const trimmed = line.trim();
+    if (/^import\s.+from\s+["'].+["'];?$/.test(trimmed)) continue;
+    if (/^\{\/\*.*\*\/\}$/.test(trimmed)) continue;
+    if (trimmed === '<section class="prose">' || trimmed === "</section>") continue;
+    out.push(line);
+  }
+  return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export function pageUrl(site, collection, id, ext = "") {
+  const base = collection === "docs" ? "docs" : "components";
+  return new URL(`/${base}/${id}${ext}`, site).href;
+}
+
+// Full markdown document for one entry, served at its .md twin URL
+// and embedded in /llms-full.txt.
+export function pageMarkdown(entry, collection, site) {
+  const canonical = pageUrl(site, collection, entry.id);
+  return [
+    `# ${entry.data.title}`,
+    "",
+    `> Part of mCSS (${new URL(site).host}). Rendered page: ${canonical}`,
+    "",
+    cleanMdxBody(entry.body),
+    "",
+  ].join("\n");
+}
+
+export const markdownResponse = (text) =>
+  new Response(text, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });


### PR DESCRIPTION
Makes mCSS friendly to AI coding agents:

- **/llms.txt** index and **/llms-full.txt** (the entire docs and components reference in one markdown file), generated from the content collections at build time so they can never drift from the docs.
- **Markdown twins**: every docs and components page is also served at the same URL with `.md` appended (`/docs/tokens.md`, `/components/card.md`). MDX imports, comments, and prose wrappers are stripped; code fences are left untouched.
- **New "AI Agents" docs page** with a ready-to-paste rules block for consumers' `CLAUDE.md` / `AGENTS.md`, framed around the copy-it-you-own-it philosophy.
- **`rel="alternate" type="text/markdown"`** links on docs and components pages so tooling can discover the twins.
- Docs pages gained optional `description` frontmatter, used by llms.txt and now also by meta descriptions (docs layouts pass frontmatter through to BaseLayout).
- Removed unused npm publish fields from package.json (mCSS is not a registry package).

Verified against a production build: all endpoints return clean markdown, sidebar shows the new page, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)