### PR TITLE
Fix cascade comments that overstate the unlayered-CSS guarantee

### DIFF
--- a/src/content/docs/start.mdx
+++ b/src/content/docs/start.mdx
@@ -55,8 +55,10 @@ This is how mCSS is organized. ([Github source][4].)
 @import url(./help.spacing.css) layer(helpers);
 /* etc. */
 
-/* Your site's own CSS imports UNLAYERED, after the framework:
-   it wins over every mCSS layer without fighting specificity. */
+/* Your site's own CSS imports UNLAYERED, after the framework.
+   Its normal declarations win over every mCSS layer without fighting
+   specificity. One exception: helpers are !important and beat
+   unlayered CSS too. */
 @import url(./site/myComponent.css);
 ```
 

--- a/src/styles/_global.css
+++ b/src/styles/_global.css
@@ -3,9 +3,11 @@
 
 /*
   Site-only styles (docs site chrome, internal components, pages).
-  UNLAYERED: they beat the framework layers and match the cascade of other
-  unlayered site CSS (expressive-code, Astro scoped styles). Site rules that
-  helpers should still override go in a lower layer, e.g. @layer pages { … }.
+  UNLAYERED: their normal declarations beat the framework layers and match
+  the cascade of other unlayered site CSS (expressive-code, Astro scoped
+  styles). Helpers still win everywhere: their !important declarations beat
+  unlayered CSS too. Use @layer pages { … } for site rules that should stay
+  below your unlayered CSS while still beating the framework's components.
 */
 @import url(./site/component.header.css);
 @import url(./site/component.themeToggle.css);


### PR DESCRIPTION
## Summary

Two comments claimed unlayered site CSS "wins over every mCSS layer". That is only true for normal declarations: every helper declaration is `!important`, and important layered declarations beat unlayered CSS, so helpers win over site and consumer CSS by design. The prose in `docs/start` ("Your CSS (unlayered)" section) and `agents/css.md` already state the exception correctly; these two comments contradicted them.

- **`docs/start` code block**: now says normal declarations win over every layer, with the helpers exception spelled out.
- **`_global.css`**: same fix, plus a corrected rationale for `@layer pages`. The old comment said pages exists so "helpers can still override" those rules, but helpers override unlayered rules too, so that reasoning was based on the same false premise. Pages is for site rules that should stay below your unlayered CSS while still beating the framework's components.

Comment-only change: no rendered CSS or dist output is affected.

## Verification

- `npm run build` passes; the rebuilt `/docs/start` shows the corrected code block and the old claim is gone.
- `grep -rn "wins over every"` no longer matches anywhere in src.

🤖 Generated with [Claude Code](https://claude.com/claude-code)