### PR TITLE
Fix single-word avatar initials

### DIFF
--- a/src/scripts/utilities.js
+++ b/src/scripts/utilities.js
@@ -43,7 +43,9 @@ export function moveToFirstPosition(arr, key, value) {
   return arr;
 }
 
-export function getInitials(name = ":)") {
+// Pre-computed initials pass through untouched; a single-word name yields one
+// initial, and anything longer yields first and last.
+export function getInitials(name = "") {
   const fullName = name.trim();
   if (fullName.length <= 2) {
     return fullName.toUpperCase();
@@ -51,7 +53,10 @@ export function getInitials(name = ":)") {
   const names = fullName.split(/\s+/);
   const firstName = names[0];
   const lastName = names[names.length - 1];
-  const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`;
+  const initials =
+    names.length === 1
+      ? firstName.charAt(0)
+      : `${firstName.charAt(0)}${lastName.charAt(0)}`;
   return initials.toUpperCase();
 }
 


### PR DESCRIPTION
## Problem

`getInitials` doubled the first letter of a one-word name, so an author of `Yann` rendered as **YY** on the blog index cards (all 20 of them).

With a single name, `names[0]` and `names[names.length - 1]` are the same array element, so the function concatenated the same character twice. The `fullName.length <= 2` early return only shielded strings of two characters or fewer, so `Yann` fell through to the two-name path.

## Fix

Single-word names now yield one initial. Two changes worth calling out:

- **Pre-computed initials still pass through.** The `length <= 2` branch is kept, because the avatar docs document `<Avatar>SR</Avatar>` as a supported way to hand the component initials directly. Without it, `SR` rendered as `S`.
- **The `":)"` default is gone**, replaced with an empty string.

Known limitation: a two-letter single name like `Jo` still returns `JO`, since it is indistinguishable from pre-computed initials. Separating the two cases would need an explicit prop.

## Verification

Checked the rendered DOM on the dev server:

- `/blog`: all 20 cards render `Y` (was `YY`).
- `/components/avatar`: `Sonny Rollins` to `SR`, literal `SR` to `SR`, image variants unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)