### PR TITLE
Blog post: show where postcss-mixins goes in the config

### DIFF
--- a/src/content/blog/postcss-setup-for-mcss.mdx
+++ b/src/content/blog/postcss-setup-for-mcss.mdx
@@ -96,6 +96,10 @@ const postcssPresetEnv = require("postcss-preset-env");
 
 module.exports = {
   plugins: [
+    // Uncomment if you opted into mixins. It has to run before preset-env,
+    // so the mixins are already expanded before anything else transforms
+    // the file.
+    // require("postcss-mixins"),
     postcssPresetEnv({
       stage: 2,
       features: {
@@ -149,7 +153,7 @@ You are done. Astro, Vite, Next, Nuxt, SvelteKit, Parcel, and anything else with
 import "./styles/main.css";
 ```
 
-Bundlers also inline the `@import` chain themselves, which matters more than it looks: `@custom-media` definitions only apply within the stylesheet PostCSS is processing, so the breakpoint file has to be pulled into the same document as the files that use it. Your bundler is already doing that. (This site is an Astro project and its PostCSS config is exactly the file above, nothing more.)
+Bundlers also inline the `@import` chain themselves, which matters more than it looks: `@custom-media` definitions only apply within the stylesheet PostCSS is processing, so the breakpoint file has to be pulled into the same document as the files that use it. Your bundler is already doing that. (This site is an Astro project and its PostCSS config is the file above with the `postcss-mixins` line uncommented, nothing more.)
 
 Run your usual `dev` and `build`. Nothing else changes.
 
@@ -170,6 +174,7 @@ const postcssPresetEnv = require("postcss-preset-env");
 module.exports = {
   plugins: [
     require("postcss-import"),
+    // require("postcss-mixins"), // if you opted in
     postcssPresetEnv({
       stage: 2,
       features: {
@@ -181,7 +186,7 @@ module.exports = {
 };
 ```
 
-Order is not a style preference here. Put it last and preset-env sees a file full of `@media (--md)` with no definitions in scope, leaves them alone, and ships them to the browser broken.
+Order is not a style preference here. Put it last and preset-env sees a file full of `@media (--md)` with no definitions in scope, leaves them alone, and ships them to the browser broken. Mixins follow the same logic: `postcss-mixins` needs `postcss-import` to have inlined the `@define-mixin` blocks first, and preset-env wants the mixins already expanded, so the order is always import, mixins, preset-env.
 
 Then point a script at your entry file:
 


### PR DESCRIPTION
## What changed

The PostCSS setup post ([postcss-setup-for-mcss.mdx](../blob/main/src/content/blog/postcss-setup-for-mcss.mdx)) told readers to `npm install -D postcss-mixins` if they want mixins, but neither of its two `postcss.config.cjs` code blocks ever showed the plugin in the plugins array. Readers who opted in were left to guess where it goes.

- The main (bundler) config block now has a commented `// require("postcss-mixins"),` line at the top of the plugins array, with a note that it must run before preset-env.
- The no-bundler config block has the same commented line between `postcss-import` and preset-env, and the "Order is not a style preference" paragraph now states the full rule: import, then mixins, then preset-env. This matches the repo's own `postcss.config.cjs` and `src/tools/build-css.mjs`.
- The claim that this site's PostCSS config "is exactly the file above, nothing more" was inaccurate, since the site's config includes postcss-mixins. It now says the config is the file above with the mixins line uncommented.

## Why

The docs page `start.mdx` says mixins "require a PostCSS plugin to work" and links to this post, so the post should actually show the wiring. Without it, the post's "exactly the file above" sentence also contradicted the repo's real config.

## Notes for review

Prose-only change to one blog post; no code or config touched. Plugin order was verified against `src/tools/build-css.mjs` (`postcssImport` then `postcssMixins` then `postcssPresetEnv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)