### PR TITLE
Docs: tell PostCSS installers to copy .browserslistrc too

### DIFF
--- a/src/content/docs/start.mdx
+++ b/src/content/docs/start.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started"
 description: "Copy mCSS into your project and learn the methodology: file structure, class syntax, components"
-lastUpdate: 2026-07-28
+lastUpdate: 2026-07-31
 version: 1
 ---
 
@@ -24,7 +24,7 @@ There is nothing to install from a registry: you copy mCSS into your project and
 
 ### Install with PostCSS
 
-Copy [`src/styles/framework/`][framework-src] to wherever your CSS lives, then start your own folder next to it for your unlayered CSS. This site's [`site/`][site-src] is the worked example of that folder, and [`_global.css`][4] is the entry file tying the two together (see [the layers](#mcss-file-structure) below).
+Copy [`src/styles/framework/`][framework-src] to wherever your CSS lives, then start your own folder next to it for your unlayered CSS. This site's [`site/`][site-src] is the worked example of that folder, and [`_global.css`][4] is the entry file tying the two together (see [the layers](#mcss-file-structure) below). Copy [`.browserslistrc`][browserslistrc] from the repo root as well: it sets the [compile floor](#browser-support) that keeps postcss-preset-env from polyfilling the features mCSS uses natively.
 
 You own the source this way: tokens, components, and themes are all editable, and you only ship the files you actually import. The cost is a build step, because the source uses `@custom-media`, which no browser understands yet. One plugin ([postcss-preset-env][presetEnv]) and a five-line config resolve it, and if you already use Astro, Vite, Next, or any other bundler, that config is the only thing you add. If you need more details on how to set up PostCSS, see [this blog post][postcss-post].
 
@@ -426,6 +426,7 @@ The exact compile floor lives in `.browserslistrc` (`baseline 2024`). Keep it: w
 [a11y]: /docs/global#accessibility
 [bem]: /blog/what-is-bem
 [bemit]: https://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/
+[browserslistrc]: https://github.com/minimaldesign/mCSS/blob/main/.browserslistrc
 [components]: /components/start
 [coupling]: /blog/component-system-that-scales
 [discussions]: https://github.com/minimaldesign/mCSS/discussions


### PR DESCRIPTION
## What changed

One sentence added to [Install with PostCSS](https://mcss.dev/docs/start#install-with-postcss) in `src/content/docs/start.mdx`:

> Copy [`.browserslistrc`][browserslistrc] from the repo root as well: it sets the [compile floor](#browser-support) that keeps postcss-preset-env from polyfilling the features mCSS uses natively.

Plus the `[browserslistrc]` link reference (alphabetical, between `bemit` and `components`) and a `lastUpdate` bump to 2026-07-31.

## Why

The install section enumerates what a source install copies: `src/styles/framework/`, your own folder next to it, the entry file. `.browserslistrc` was not on that list, so an installer inherits whatever target the host project already has. That is the exact condition #56 was about: a broader target and postcss-preset-env starts polyfilling `light-dark()` and flattening nesting again, undoing what 1.3.0 just fixed.

The Browser support section (line 415) already says to keep the file, but only someone who reads that far finds out it exists. This links to it from the point where the copying happens.

## Notes for review

- Prose-only, one file. No CSS, no config, no `dist/` churn.
- `lastUpdate` was still 2026-07-28 even though #57 rewrote the Browser support section on the 31st, so this bump also catches that up. Drop it if you would rather the date tracked only this change.
- Verified in the production build: both links render, and `id="browser-support"` exists in the output so the in-page anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)